### PR TITLE
Fix startup on macOS

### DIFF
--- a/src/utils/DeezerWebSocket.ts
+++ b/src/utils/DeezerWebSocket.ts
@@ -20,7 +20,7 @@ export function start() {
   socket.on('listening', () => {
     const interfaces = os.networkInterfaces();
     const ip = (
-      interfaces['Wi-Fi'] || interfaces['Ethernet'] || interfaces['en1']
+      interfaces['Wi-Fi'] || interfaces['Ethernet'] || interfaces['en0'] || interfaces['en1'] 
     ).find(i => i.family === 'IPv4').address;
     log('Local WS', `Started server on ws://${ip}:${port}`);
   });


### PR DESCRIPTION
The "Wi-FI", "Ethernet" and "en1" interfaces don't exist on macOS, at least not on my side on macOS Ventura 13.4.1.
<img width="402" alt="image" src="https://github.com/JustYuuto/deezer-discord-rpc/assets/24718500/49e9f83a-0390-434c-a48a-b41a86018c33">

This returns an error every time the application is started.
<img width="1506" alt="image" src="https://github.com/JustYuuto/deezer-discord-rpc/assets/24718500/ae420f7e-1662-4f9e-a6c5-dbcca67b1355">

This PR corrects this problem by also supporting "en0", which returns the local IP of the computer on the local network.