### PR TITLE
fix: linux icon and category

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -23,9 +23,9 @@ const config = {
     icon: join(__dirname, '..', 'src', 'img', 'app.ico'),
   },
   linux: {
-    category: 'Audio',
+    category: 'Audio;AudioVideo',
     target: ['snap', 'deb', 'AppImage'],
-    icon: join(__dirname, '..', 'src', 'img', 'app.png'),
+    icon: join(__dirname, '..', 'src', 'img', 'app.icns'),
   },
   files: [
     '!src/*',


### PR DESCRIPTION
When putting Audio as the Linux category for the app, we need to add AudioVideo so that it goes in the good category in the app menu.
It's best to generate the Linux icons from the macOS format as the png is bugged and doesn't generate the icon properly for the deb package.