### PR TITLE
Add RPM build for fedora and update the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,53 @@
 
 ![Tray menu](screenshots/tray_menu.png)
 
+## How To build yourself (on linux)
+If your not using a red-hat system make sure you have the build tools for rmp package
+
+#### Install the rpm-build package
+```
+sudo apt install rpm-build
+or
+sudo dnf install rpm-build
+```
+
+#### Clone the repo
+
+```
+git clone https://github.com/JustYuuto/deezer-discord-rpc
+cd ./deezer-discord-rpc
+```
+
+#### Build the app with docker
+
+> [!NOTE]  
+> OFC, You have to install docker!  
+
+```
+docker run --rm -ti \
+ --env-file <(env | grep -iE 'DEBUG|NODE_|ELECTRON_|YARN_|NPM_|CI|CIRCLE|TRAVIS_TAG|TRAVIS|TRAVIS_REPO_|TRAVIS_BUILD_|TRAVIS_BRANCH|TRAVIS_PULL_REQUEST_|APPVEYOR_|CSC_|GH_|GITHUB_|BT_|AWS_|STRIP|BUILD_') \
+ --env ELECTRON_CACHE="/root/.cache/electron" \
+ --env ELECTRON_BUILDER_CACHE="/root/.cache/electron-builder" \
+ -v ${PWD}:/project \
+ -v ${PWD##*/}-node-modules:/project/node_modules \
+ -v ~/.cache/electron:/root/.cache/electron \
+ -v ~/.cache/electron-builder:/root/.cache/electron-builder \
+ electronuserland/builder:wine
+```
+
+##### Build the app
+
+```
+# npm install
+# npm run build
+```
+
+#### Get the builded package
+
+You can get the builded package directly in the ```dist``` folder
+
+<br>
+
 ## Todo
 
 * [x] Implement Discord WebSocket server to get a "Listening to" status on the profile

--- a/bin/build.js
+++ b/bin/build.js
@@ -24,7 +24,7 @@ const config = {
   },
   linux: {
     category: 'Audio;AudioVideo',
-    target: ['snap', 'deb', 'AppImage'],
+    target: ['snap', 'deb', 'AppImage', 'rpm'], // Added 'rpm' here for Fedora packaging
     icon: join(__dirname, '..', 'src', 'img', 'app.icns'),
   },
   files: [
@@ -44,7 +44,7 @@ const options = {
 };
 if (process.platform === 'darwin') options.mac = ['dmg'];
 // Linux programs like chmod are not supported on Windows
-if (process.platform !== 'win32') options.linux = ['snap', 'deb', 'AppImage'];
+if (process.platform !== 'win32') options.linux = ['snap', 'deb', 'AppImage, rpm'];
 
 builder.build(options).then(() => {
   console.log('\nSetup built in the "dist" folder.');


### PR DESCRIPTION
This pull request updates the `README.md` file to include detailed instructions on how to build the project on Linux and add the **RPM build for fedora** 
The most important changes include steps for installing necessary packages, cloning the repository, building the app with Docker, and locating the built package.

Build instructions added:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R84): Added a new section "How To build yourself (on linux)" with steps for installing `rpm-build` package, cloning the repository, building the app using Docker, and locating the built package in the `dist` folder.